### PR TITLE
Fix readme

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -6,7 +6,7 @@ tags:
   - provider/aws
 ---
 
-# Component: `datadog`
+# Component: `datadog-credentials`
 
 This component is responsible for provisioning SSM or ASM entries for Datadog API keys.
 


### PR DESCRIPTION
## what
- Copy CHANGELOG.md to `src/CHANGELOG.md`
- Generate `src/README.md` from `README.yaml`

## why
- `atmos vendor` should get readme files
