### PR TITLE
Use account-map by git reference

### DIFF
--- a/src/modules/datadog_keys/providers.tf
+++ b/src/modules/datadog_keys/providers.tf
@@ -15,6 +15,6 @@ provider "aws" {
 }
 
 module "iam_roles" {
-  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/?ref=tags/v1.535.3"
+  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles?ref=tags/v1.535.3"
   context = module.this.context
 }

--- a/src/modules/datadog_keys/providers.tf
+++ b/src/modules/datadog_keys/providers.tf
@@ -15,6 +15,6 @@ provider "aws" {
 }
 
 module "iam_roles" {
-  source  = ""github.com/cloudposse-terraform-components/aws-account-map//src/?ref=tags/v1.535.3"
+  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/?ref=tags/v1.535.3"
   context = module.this.context
 }

--- a/src/modules/datadog_keys/providers.tf
+++ b/src/modules/datadog_keys/providers.tf
@@ -15,6 +15,6 @@ provider "aws" {
 }
 
 module "iam_roles" {
-  source  = "../../../account-map/modules/iam-roles"
+  source  = ""github.com/cloudposse-terraform-components/aws-account-map//src/?ref=tags/v1.535.3"
   context = module.this.context
 }

--- a/src/provider-datadog.tf
+++ b/src/provider-datadog.tf
@@ -16,7 +16,7 @@ provider "aws" {
 }
 
 module "iam_roles_datadog_secrets" {
-  source  = "../account-map/modules/iam-roles"
+  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles?ref=tags/v1.535.3"
   stage   = var.datadog_secrets_source_store_account_stage
   tenant  = var.datadog_secrets_source_store_account_tenant
   context = module.this.context

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -14,6 +14,6 @@ provider "aws" {
 }
 
 module "iam_roles" {
-  source  = "../account-map/modules/iam-roles"
+  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/?ref=tags/v1.535.3"
   context = module.this.context
 }

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -14,6 +14,6 @@ provider "aws" {
 }
 
 module "iam_roles" {
-  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/?ref=tags/v1.535.3"
+  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles?ref=tags/v1.535.3"
   context = module.this.context
 }


### PR DESCRIPTION
## what
* Use account-map by git reference

## why
* Solve complex nested levels of account map deps

## references
* https://github.com/cloudposse-terraform-components/aws-datadog-lambda-forwarder/actions/runs/15428924833/job/43422611808?pr=32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated module source to use a specific tagged version from a remote repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->