### PR TITLE
Bugfix: Providers tf ref

### DIFF
--- a/src/modules/datadog_keys/providers.tf
+++ b/src/modules/datadog_keys/providers.tf
@@ -15,6 +15,6 @@ provider "aws" {
 }
 
 module "iam_roles" {
-  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles?ref=tags/v1.535.3"
+  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles?ref=v1.535.3"
   context = module.this.context
 }


### PR DESCRIPTION
This pull request includes a minor change to the `src/modules/datadog_keys/providers.tf` file. The change updates the `source` URL for the `iam_roles` module to remove the `tags/` prefix in the version reference.


# Refs
* https://github.com/cloudposse/test-harness/pull/56
* https://github.com/hashicorp/go-getter/issues/469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the reference format for an internal module to improve consistency. No impact on user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->