### PR TITLE
Generate readme for submodules

### DIFF
--- a/atmos.yaml
+++ b/atmos.yaml
@@ -9,3 +9,65 @@
 # Import shared configuration used by all modules
 import:
   - https://raw.githubusercontent.com/cloudposse-terraform-components/.github/refs/heads/main/.github/atmos/terraform-component.yaml
+
+docs:
+  generate:
+    readme-submodule:
+      base-dir: ./
+      input:
+        - readme: "./src/modules/datadog_keys/README.md"
+        - get_support: true
+      template: "https://raw.githubusercontent.com/cloudposse-terraform-components/.github/refs/heads/main/atmos.README.md.submodule.gotmpl"
+      output: "./src/modules/datadog_keys/README.md"
+      terraform:
+        source: ./src/modules/datadog_keys
+        enabled: true
+        format: "markdown table"
+        show_providers: false
+        show_inputs: true
+        show_outputs: true
+        sort_by: "name"
+        hide_empty: false
+        indent_level: 2
+
+commands:
+- name: readme
+  steps:
+    - "atmos docs generate readme"
+    - "atmos docs generate readme-simple"
+    - "atmos docs generate readme-submodule"
+
+- name: test
+  commands:
+  - name: "deploy"
+    description: Deploy
+    commands:
+      - name: "dependencies"
+        description: Deploy dependencies only
+        steps:
+          - "cd test"
+          - "go test -timeout 1h --only-deploy-dependencies --skip-destroy-dependencies"
+
+      - name: "component"
+        description: Deploy component only
+        steps:
+          - "cd test"
+          - "go test -timeout 1h --skip-deploy-dependencies --skip-destroy-dependencies --skip-destroy-component"
+
+  - name: "assert"
+    description: Run asserts
+    steps:
+      - "cd test"
+      - "go test -timeout 1h --skip-deploy-dependencies --skip-destroy-dependencies --skip-deploy-component --skip-destroy-component"
+
+  - name: "destroy"
+    description: Destroy
+    steps:
+      - "cd test"
+      - "go test -timeout 1h --skip-deploy-dependencies --skip-deploy-component"
+
+  - name: "run"
+    description: Run tests
+    steps:
+      - "cd test"
+      - "go test -timeout 1h"

--- a/src/modules/datadog_keys/README.md
+++ b/src/modules/datadog_keys/README.md
@@ -28,7 +28,9 @@ provider "datadog" {
 ```
 
 <!-- prettier-ignore-start -->
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -48,7 +50,7 @@ provider "datadog" {
 |------|--------|---------|
 | <a name="module_always"></a> [always](#module\_always) | cloudposse/label/null | 0.25.0 |
 | <a name="module_datadog_configuration"></a> [datadog\_configuration](#module\_datadog\_configuration) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles | v1.535.5 |
+| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles | v1.536.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_utils_example_complete"></a> [utils\_example\_complete](#module\_utils\_example\_complete) | cloudposse/utils/aws | 1.4.0 |
 
@@ -96,5 +98,7 @@ provider "datadog" {
 | <a name="output_datadog_secrets_store_type"></a> [datadog\_secrets\_store\_type](#output\_datadog\_secrets\_store\_type) | The type of the secrets store to use for Datadog API and APP keys |
 | <a name="output_datadog_site"></a> [datadog\_site](#output\_datadog\_site) | Datadog Site |
 | <a name="output_datadog_tags"></a> [datadog\_tags](#output\_datadog\_tags) | The Context Tags in datadog tag format (list of strings formatted as 'key:value') |
+<!-- markdownlint-restore -->
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
## what
* Generate readme for submodules

## why
* Allow all to keep the README updated

## references
* https://linear.app/cloudposse/issue/DEV-3521/make-cicd-workflow-support-readmes-in-modules-subfolders


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Automated README generation for the datadog_keys module with configuration-driven settings.
  * Added pre-commit hooks for documentation consistency and formatting.

* **Chores**
  * Updated module dependencies to latest versions.
  * Added command workflows for documentation and test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->